### PR TITLE
defaults.runs-on

### DIFF
--- a/.github/workflows/defaults.runs-on.yml
+++ b/.github/workflows/defaults.runs-on.yml
@@ -1,0 +1,7 @@
+on: push
+defaults:
+  runs-on: ubuntu-latest
+jobs:
+  foo:
+    steps:
+      - uses: actions/checkout@v2


### PR DESCRIPTION
## Is it possible to set `runs-on` as a global default?

[No.](https://github.com/aureliojargas/github-actions-sandbox/actions/workflows/defaults.runs-on.yml)

> The workflow is not valid. .github/workflows/defaults.yml 
> (Line: 3, Col: 3): Unexpected value 'runs-on' .github/workflows/defaults.yml
> (Line: 6, Col: 5): Required property is missing: runs-on

Looks like only the documented [defaults.run](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#defaultsrun) is allowed.
