### PR TITLE
runner-environment

### DIFF
--- a/.github/workflows/runner-environment.yml
+++ b/.github/workflows/runner-environment.yml
@@ -1,0 +1,62 @@
+on: push
+jobs:
+  runner-environment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cat /etc/os-release
+      - run: uname -a
+      - run: python3 --version
+      - run: git --version
+      - run: bash --version | head -n 1
+      - run: ls -l $(which sh)
+      - run: dpkg -s dash | grep Version
+      - run: sed --version | head -n 1
+      - run: id
+      - run: pwd
+      - run: "echo $PATH | tr : '\n'"
+      - run: |
+          find $HOME \
+            -not -path '/home/runner/.nvm/*' \
+            -not -path '/home/runner/runners/*'
+
+  # Shell-specific data
+
+  shell-default:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          echo '2021-06-30: shell: /usr/bin/bash -e {0}'
+      - run: alias
+      - run: trap
+      - run: set -o
+      - run: set
+
+  shell-bash:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          echo '2021-06-30: shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}'
+      - run: alias
+      - run: trap
+      - run: set -o
+      - run: set
+
+  shell-sh:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: sh
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          echo '2021-06-30: shell: /usr/bin/sh -e {0}'
+      - run: alias
+      - run: trap
+      - run: set -o
+      - run: set


### PR DESCRIPTION
The following is just a summary. For the raw data see the logs in the Checks tab.

## Software versions

- Ubuntu 20.04.2 LTS (Focal Fossa)
- Python 3.8.5 👈 
- git 2.32.0
- bash 5.0.17
- dash 0.5.10.2 (`sh`)
- [more](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md)

## CI-related environment variables

- CI=`true`
- GITHUB_JOB=`<job-name>`
- GITHUB_REF=`refs/heads/runner-environment`
- GITHUB_REPOSITORY=`aureliojargas/github-actions-sandbox`
- GITHUB_SHA=`2012ea194cd8a2b3d47d9c070a4353824f0d8c66` (HEAD commit)
- GITHUB_WORKFLOW=`.github/workflows/runner-environment.yml`
- GITHUB_WORKSPACE=`/home/runner/work/github-actions-sandbox/github-actions-sandbox`

## Environment
 
- USER=`runner`
- UID=`1001`
- HOME=`/home/runner`
- LANG=`C.UTF-8` 👈 
- TERM=`dumb` 👈 
- PWD=`/home/runner/work/github-actions-sandbox/github-actions-sandbox`
- PATH=
    ```
    /home/linuxbrew/.linuxbrew/bin
    /home/linuxbrew/.linuxbrew/sbin
    /home/runner/.local/bin
    /opt/pipx_bin
    /usr/share/rust/.cargo/bin
    /home/runner/.config/composer/vendor/bin
    /usr/local/.ghcup/bin
    /home/runner/.dotnet/tools
    /snap/bin
    /usr/local/sbin
    /usr/local/bin
    /usr/sbin
    /usr/bin
    /sbin
    /bin
    /usr/games
    /usr/local/games
    /snap/bin
    ```

## Shell call

- Default (no `shell:` specified) → `/usr/bin/bash -e {0}`
- `shell: bash` → `/usr/bin/bash --noprofile --norc -e -o pipefail {0}`
- `shell: sh` → `/usr/bin/sh -e {0}`
- [source code](https://github.com/actions/runner/blob/be9632302ceef50bfb36ea998cea9c94c75e5d4d/src/Runner.Worker/Handlers/ScriptHandlerHelpers.cs#L14-L15)

## Important

- `SIGPIPE` is trapped and ignored in all shells. See details in #4.

- `set -o pipefail` is only set when using `shell: bash`.

- No shell aliases are defined in any shell type.