### PR TITLE
trap SIGPIPE

### DIFF
--- a/.github/workflows/sigpipe.yml
+++ b/.github/workflows/sigpipe.yml
@@ -68,9 +68,16 @@ jobs:
     steps:
       - name: >
           Use env --default-signal=PIPE as shell to restore SIGPIPE
-          default behavior.
+          default behavior. Error 141.
+        continue-on-error: true  # Error: Process completed with exit code 141.
         run: yes | head -n 1
         shell: env --default-signal=PIPE bash --noprofile --norc -eo pipefail {0}
+
+      - name: Prefix the first command with env --default-signal=PIPE
+        run: env --default-signal=PIPE yes | head -n 1
+
+      - name: Run the whole command with env --default-signal=PIPE, using bash -c
+        run: env --default-signal=PIPE bash -c 'yes | head -n 1'
 
   fix-using-python:
     runs-on: ubuntu-latest

--- a/.github/workflows/sigpipe.yml
+++ b/.github/workflows/sigpipe.yml
@@ -73,23 +73,23 @@ jobs:
         run: true
 
       - name: Use python -c to un-ignore SIGPIPE (should PASS)
-        run: python3 -c 'import subprocess as s; s.run(["trap; yes | head -n 1"], shell=True, check=True)'
+        run: python3 -c 'import subprocess as s; s.run("trap; yes | head -n 1", shell=True, check=True)'
 
       - name: Use python -c to un-ignore SIGPIPE (should FAIL)
-        run: python3 -c 'import subprocess as s; s.run(["false"], shell=True, check=True)'
+        run: python3 -c 'import subprocess as s; s.run("false", shell=True, check=True)'
         continue-on-error: true
 
       - name: Using Python as shell to run shell commands - cmd=
         run: |
           cmd = "trap; yes | head -n 1"
-          import subprocess as s; s.run([cmd], shell=True, check=True)
+          import subprocess as s; s.run(cmd, shell=True, check=True)
         shell: python
 
       - name: Using Python as shell to run shell commands - env var
         env:
           CMD: "trap; yes | head -n 1"
         run: |
-          import os, subprocess as s; s.run([os.environ["CMD"]], shell=True, check=True)
+          import os, subprocess as s; s.run(os.environ["CMD"], shell=True, check=True)
         shell: python
 
       - name: >
@@ -99,4 +99,4 @@ jobs:
         run: |
           trap; yes | head -n 1
         shell: |
-          python3 -c 'import subprocess as s; with open("{0}") as f: s.run([f.read()], shell=True, check=True)'
+          python3 -c 'import subprocess as s; with open("{0}") as f: s.run(f.read(), shell=True, check=True)'

--- a/.github/workflows/sigpipe.yml
+++ b/.github/workflows/sigpipe.yml
@@ -1,0 +1,102 @@
+on: push
+jobs:
+  sigpipe:
+    runs-on: ubuntu-latest
+    steps:
+      # Sometimes SIGPIPE is ignored
+
+      - name: Is SIGPIPE trapped and ignored? YES -- no shell specified
+        run: trap
+
+      - name: Is SIGPIPE trapped and ignored? YES -- shell:bash
+        run: trap
+        shell: bash
+
+      - name: Is SIGPIPE trapped and ignored? YES -- shell:sh
+        run: |
+          trap
+          echo '^ trap output was empty, but SIGPIPE is ignored (see broken pipe error):'
+          yes | head -n 1
+        shell: sh
+
+      # Sometimes pipefail is active
+
+      - name: Is pipefail active? NO -- no shell specified
+        run: set -o | grep -e pipefail
+
+      - name: Is pipefail active? YES -- shell:bash
+        run: set -o | grep -e pipefail
+        shell: bash
+
+      - name: Is pipefail active? NO (not supported) -- shell:sh
+        continue-on-error: true
+        run: set -o | grep -e pipefail
+        shell: sh
+
+      - name: >
+          When SIGPIPE is ignored and pipefail is active, common
+          commands may fail with "broken pipe" error
+        continue-on-error: true
+        run: yes | head -n 1
+        shell: bash
+
+      - name: >
+          By disabling pipefail, usual SIGPIPE is not fatal, but stdout
+          is filled with "broken pipe" error messages
+        run: set +o pipefail; yes | head -n 1
+        shell: bash
+
+      - name: >
+          Same as previous step, but disabling pipefail with a custom
+          shell call that does not mention pipefail
+        run: yes | head -n 1
+        shell: bash --noprofile --norc -e {0}
+
+  fix-using-env:
+    runs-on: ubuntu-latest
+    steps:
+      - name: >
+          Use env --default-signal=PIPE as shell to restore SIGPIPE
+          default behavior. NOT SUPPORTED in Ubuntu 20.04, maybe in the
+          next version.
+        continue-on-error: true
+        run: yes | head -n 1
+        shell: env --default-signal=PIPE bash --noprofile --norc -eo pipefail {0}
+
+  fix-using-python:
+    runs-on: ubuntu-latest
+    steps:
+      - name: >
+          Shell scripts cannot un-ignore a trap, but other languages
+          can. Use Python. Note that Python already un-ignores it by
+          default, there is no need to do it explicitly.
+        run: true
+
+      - name: Use python -c to un-ignore SIGPIPE (should PASS)
+        run: python3 -c 'import subprocess as s; s.run(["trap; yes | head -n 1"], shell=True, check=True)'
+
+      - name: Use python -c to un-ignore SIGPIPE (should FAIL)
+        run: python3 -c 'import subprocess as s; s.run(["false"], shell=True, check=True)'
+        continue-on-error: true
+
+      - name: Using Python as shell to run shell commands - cmd=
+        run: |
+          cmd = "trap; yes | head -n 1"
+          import subprocess as s; s.run([cmd], shell=True, check=True)
+        shell: python
+
+      - name: Using Python as shell to run shell commands - env var
+        env:
+          CMD: "trap; yes | head -n 1"
+        run: |
+          import os, subprocess as s; s.run([os.environ["CMD"]], shell=True, check=True)
+        shell: python
+
+      - name: >
+          Using "python -c" as the shell to run shell commands (DOES NOT WORK
+          and I don't know why)
+        continue-on-error: true
+        run: |
+          trap; yes | head -n 1
+        shell: |
+          python3 -c 'import subprocess as s; with open("{0}") as f: s.run([f.read()], shell=True, check=True)'

--- a/.github/workflows/sigpipe.yml
+++ b/.github/workflows/sigpipe.yml
@@ -52,14 +52,23 @@ jobs:
         run: yes | head -n 1
         shell: bash --noprofile --norc -e {0}
 
-  fix-using-env:
-    runs-on: ubuntu-latest
+  fix-using-env-ubuntu-20-04:
+    runs-on: ubuntu-20.04
     steps:
       - name: >
           Use env --default-signal=PIPE as shell to restore SIGPIPE
           default behavior. NOT SUPPORTED in Ubuntu 20.04, maybe in the
           next version.
         continue-on-error: true
+        run: yes | head -n 1
+        shell: env --default-signal=PIPE bash --noprofile --norc -eo pipefail {0}
+
+  fix-using-env-ubuntu-22-04:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: >
+          Use env --default-signal=PIPE as shell to restore SIGPIPE
+          default behavior.
         run: yes | head -n 1
         shell: env --default-signal=PIPE bash --noprofile --norc -eo pipefail {0}
 


### PR DESCRIPTION
## The problem

GitHub Actions runner environment by default ignores SIGPIPE :(

```console
$ trap
trap -- '' SIGPIPE
$
```

## The consequences

That causes problems when a command should properly handle SIGPIPE instead of ignoring it. 

When SIGPIPE is not ignored:

```console
$ yes | head -n 1
y
$
```

When SIGPIPE is ignored:

```console
$ trap -- '' SIGPIPE
$ yes | head -n 1
y
yes: standard output: Broken pipe
$
```

Why the broken pipe? Read the details in https://github.com/aureliojargas/txt2regex/pull/9#issuecomment-867227525.

## The workaround using Python

Shell scripts cannot un-ignore a trap, but other languages can. So we can use Python, for example. 

```yaml
- run: |
    cmd = "trap; yes | head -n 1"
    import subprocess as s; s.run([cmd], shell=True, check=True)
  shell: python
```

> Note that Python already un-ignores SIGTRAP by default, there is no need to do it explicitly.

## The workaround using `env` in Ubuntu >= 22.04

Now that Ubuntu 22.04 is available for GitHub Actions, the `env` command has the new option `--default-signal`, which can be used to undo the trap.

For example, to run `make test` in the CI with an untrapped SIGPIPE, use:

    env --default-signal=PIPE make test
